### PR TITLE
chore: Adding GitHub Actions Release Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,10 +29,10 @@ jobs:
         cp BabelfishCompass.bat BabelfishCompass/
         cp BabelfishFeatures.cfg BabelfishCompass/
         cp THIRD-PARTY-LICENSES.txt BabelfishCompass/
-        cp target/compass-1.0-jar-with-dependencies.jar BabelfishCompass/
+        cp target/compass-*-jar-with-dependencies.jar BabelfishCompass/
         cp LICENSE BabelfishCompass/
         cp NOTICE BabelfishCompass/
-        mv BabelfishCompass/compass-1.0-jar-with-dependencies.jar BabelfishCompass/compass.jar
+        mv BabelfishCompass/compass-*-jar-with-dependencies.jar BabelfishCompass/compass.jar
         zip -r BabelfishCompass_${{ env.RELEASE_VERSION }}.zip BabelfishCompass
     - name: Upload JARs to release
       uses: ncipollo/release-action@v1


### PR DESCRIPTION
GitHub actions will be enabled to publish release artifacts.