### PR TITLE
maven-assembly-plugin does not use source or target in its configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,6 @@
         <artifactId>maven-assembly-plugin</artifactId>
         <version>${maven-assemply.version}</version>
         <configuration>
-          <source>${jre.version}</source>
-          <target>${jre.version}</target>
           <archive>
             <manifest>
               <mainClass>compass.Compass</mainClass>


### PR DESCRIPTION
### Description
Remove incompatible <source> and <target> tags from the maven-assembly-plugin configuration
 
### Issues Resolved
Resolves issue #13 
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
