### PR TITLE
chore: Adding execute permissions to BabelfishCompass.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
         cp target/compass-*-jar-with-dependencies.jar BabelfishCompass/
         cp LICENSE BabelfishCompass/
         cp NOTICE BabelfishCompass/
+        chmod +x BabelfishCompass.sh/
         cp BabelfishCompass.sh BabelfishCompass/
         mv BabelfishCompass/compass-*-jar-with-dependencies.jar BabelfishCompass/compass.jar
         zip -r BabelfishCompass_${{ env.RELEASE_VERSION }}.zip BabelfishCompass

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         cp target/compass-*-jar-with-dependencies.jar BabelfishCompass/
         cp LICENSE BabelfishCompass/
         cp NOTICE BabelfishCompass/
-        chmod +x BabelfishCompass.sh/
+        chmod +x BabelfishCompass.sh
         cp BabelfishCompass.sh BabelfishCompass/
         mv BabelfishCompass/compass-*-jar-with-dependencies.jar BabelfishCompass/compass.jar
         zip -r BabelfishCompass_${{ env.RELEASE_VERSION }}.zip BabelfishCompass


### PR DESCRIPTION
### Description
By default, users would need to grant execute permissions to BabelfishCompass.sh.
This change will make BabelfishCompass.sh executable by default.

