### PR TITLE
bash script style suggestions

### DIFF
--- a/BabelfishCompass.sh
+++ b/BabelfishCompass.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/env bash
 #
 # ------------------------------------------------------------------
 #  Babelfish Compass
@@ -9,21 +9,21 @@
 # ------------------------------------------------------------------
 #
 
-DIRECTORY=`dirname $0`
+DIRECTORY="$(dirname "$0")"
 cd "${DIRECTORY}"
-COMPASS=`pwd`
-JAVA="java"
+COMPASS="$(pwd)"
+JAVA="$(which java)"
 
 # Check for Java 8 or later
-JAVA_OUTPUT=`${JAVA} -d64 -fullversion 2>&1`
-if [ $? -ne 0 ]; then
+JAVA_OUTPUT=$(${JAVA} -d64 -fullversion 2>&1)
+if [ "$?" -ne 0 ]; then
     echo "64-bit Java/JRE not found. Please install 64-bit JRE 8 or later"
     exit 1
 fi
-JAVA_VERSION=`echo "${JAVA_OUTPUT}" | cut -d ' ' -f 4 | sed 's/"//g'`
-JAVA_VERSION_MAJOR=`echo "${JAVA_VERSION}" | cut -d '.' -f 1`
+JAVA_VERSION=$(echo "${JAVA_OUTPUT}" | cut -d ' ' -f 4 | tr -d '"')
+JAVA_VERSION_MAJOR=$(echo "${JAVA_VERSION}" | cut -d '.' -f 1)
 if [ "${JAVA_VERSION_MAJOR}" -eq 1 ]; then
-    JAVA_VERSION_MAJOR=`echo "${JAVA_VERSION}" | cut -d '.' -f 2`
+    JAVA_VERSION_MAJOR=$(echo "${JAVA_VERSION}" | cut -d '.' -f 2)
 fi
 if [ "${JAVA_VERSION_MAJOR}" -lt 8 ]; then
     echo "Babelfish Compass requires 64-bit Java/JRE 8 or later. Java version found: ${JAVA_VERSION_MAJOR}"
@@ -33,7 +33,7 @@ fi
 
 # assume Java is in the PATH, this was tested above
 # assuming 12GB is enough
-${JAVA} -server  -Xmx12g -jar compass.jar $*
+${JAVA} -server  -Xmx12g -jar compass.jar "$@"
 
 #
 # end


### PR DESCRIPTION
A few suggested changes for portability / modernization / robustness
of the BabelfishCompass.sh script:

I changed the shebang argument to '/usr/bin/env bash' for portability.
On some Mac and Linux systems, I've observed the preferred bash
being in /usr/bin, /usr/local/bin, or other locations other than /bin.
The /usr/bin/env idiom uses the first bash that is found in $PATH. Since
the script relies on $PATH to locate the 'java' executable, I presume that
type of flexibility is OK for this script.

Along the same lines, I used 'which' to determine the full path to the
java executable and assign that to ${JAVA}. To make debugging simpler
if ${JAVA} needs to be echoed later, e.g. to figure out if the right JDK/JRE
is being used.

I used $(...) notation instead of `...` throughout. Backticks are considered
obsolete from a POSIX perspective. See http://mywiki.wooledge.org/BashFAQ/082
or https://unix.stackexchange.com/questions/126927/have-backticks-i-e-cmd-in-sh-shells-been-deprecated
for why $() is preferable.

I added quotes around "$?", for consistency with other 'if [[ ]]'
arguments in the script.

I changed sed to tr in the pipeline stage that deletes double quotes.
Just to simplify the action of getting rid of such-and-such characters,
without introducing the overhead of a regexp search and replace.

I changed $* to "$@" where shellscript arguments are passed through to 'java'.
That's a change recommended by the 'shellcheck' linter utility,
to avoid problems if some of the arguments contain spaces.

Signed-off-by: John Russell <johrss@amazon.com>

### Description
Makes the script a little more portable (especially for Mac), maintainable, robust.
Reduces warnings from 'shellcheck' utility.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [Y] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
