### PR TITLE
handle cases of invalid input files

### DIFF
--- a/src/main/java/compass/Compass.java
+++ b/src/main/java/compass/Compass.java
@@ -1480,10 +1480,11 @@ public class Compass {
 
 			boolean doEncodingChecks = true;
 			int nrEncodingWarnings = 0;
-			int maxEncodingWarnings = 5;
+			int maxEncodingWarnings = 5;			
 
 			while (true) {
 				boolean somethingFoundOnLine = false;
+				boolean orphanSquareBracket = false;
 				line = inFileReader.readLine();
 				if (line == null) {
 					if (u.debugging) u.dbgOutput("end of file", u.debugBatch);
@@ -1586,8 +1587,10 @@ public class Compass {
 						}
 						if (lineCopyLoopChk > lineCopyLoopCntMax) {
 							// we seem to be in a loop...
-							if (u.debugging) u.dbgOutput("loop chk: exit: lineCopy=[" + lineCopy + "]", u.debugBatch);
-							u.appOutput("Error processing input file. Please verify input file encoding. Continuing, but errors may occur.");
+							if (u.debugging) u.dbgOutput("loop chk: exit: lineNr=["+lineNr+"] orphanSquareBracket=["+orphanSquareBracket+"] lineCopy=[" + lineCopy + "]", u.debugBatch);
+							String bracketMsg = "";
+							if (orphanSquareBracket) bracketMsg = "Possibly delimited identifier containing newline? "; 
+							u.appOutput("Error processing input file at line "+lineNr+". Is input file encoding correct? "+bracketMsg+"Continuing, but errors may occur.");
 							break;
 						}
 						if (u.debugging) u.dbgOutput("top loop: lineCopyLoopCnt=[" + lineCopyLoopCnt + "] inComment=" + inComment + ", inString=" + inString + ", lineCopy top=[" + lineCopy + "]", u.debugBatch);
@@ -1630,6 +1633,7 @@ public class Compass {
 										if (u.debugging) u.dbgOutput("bracketed identifier", u.debugBatch);
 										if (lineCopy.length() == lineCopyLen) {
 											// likely invalid syntax, avoid getting into a loop
+											orphanSquareBracket = true;
 											if (u.debugging) u.dbgOutput("ignoring orphan square bracket", u.debugBatch);
 											break;
 										}

--- a/src/main/java/compass/CompassAnalyze.java
+++ b/src/main/java/compass/CompassAnalyze.java
@@ -818,15 +818,35 @@ public class CompassAnalyze {
 		String itemLine = item +separator+ itemDetail.trim() +separator+ itemGroup.trim() +separator+ status +separator+ lineNr +separator+ u.currentAppName +separator+ u.currentSrcFile  +separator+ u.batchNrInFile +separator+ u.lineNrInFile +separator+ currentContext.trim() +separator+ subContext.trim() +separator+ misc + separator + "~" + separator;
 
 		// check for newlines -- these will mess everything up
-		// ToDo: also check for \r, \f, VT, etc.
-		if (itemLine.contains(u.newLine)) {
-			u.appOutput("Newline found in capture line: ["+itemLine+"] ");
+		// ToDo: also check for \f, VT, etc?
+		if (itemLine.contains("\r\n")) {
+			u.appOutput("CRLF found in captured item: ["+itemLine+"] ");
+			itemLine = itemLine.replaceAll("\\r\\n", "");		
 			if (CompassUtilities.devOptions) {
 				u.errorExitStackTrace();
 				// we'll never get here
 			}
-			u.appOutput("Continuing, but ignoring this item.");
-			return;
+			u.appOutput("Continuing with CRLF removed, but errors may occur.");
+		}
+
+		if (itemLine.contains("\n")) {
+			u.appOutput("Newline found in captured item: ["+itemLine+"] ");
+			itemLine = itemLine.replaceAll("\\n", "");		
+			if (CompassUtilities.devOptions) {
+				u.errorExitStackTrace();
+				// we'll never get here
+			}
+			u.appOutput("Continuing with newline removed, but errors may occur.");
+		}
+
+		if (itemLine.contains("\r")) {
+			u.appOutput("Carriage Return found in captured item: ["+itemLine+"] ");
+			itemLine = itemLine.replaceAll("\\r", "");		
+			if (CompassUtilities.devOptions) {
+				u.errorExitStackTrace();
+				// we'll never get here
+			}
+			u.appOutput("Continuing with Carriage Return removed, but errors may occur.");
 		}
 
 		// avoid end-of-input chars (\.) , for later loading into PG through COPY

--- a/src/main/java/compass/CompassUtilities.java
+++ b/src/main/java/compass/CompassUtilities.java
@@ -610,7 +610,7 @@ tooltipsHTMLPlaceholder +
 		"\\w+, option WITH EXECUTE AS OWNER"+tttSeparator+"The clause WITH EXECUTE AS CALLER for procedures, functions and triggers maps to SECURITY DEFINER in PostgreSQL. It affects only permissions in Babelfish; the name resolution aspect (as in SQL Server) does not apply in Babelfish/PostgreSQL",
 		"\\w+, option WITH EXECUTE AS SELF"+tttSeparator+"The clause WITH EXECUTE AS SELF for procedures, functions and triggers is not currently supported",
 		"\\w+, option WITH EXECUTE AS USER"+tttSeparator+"The clause WITH EXECUTE AS <user> for procedures, functions and triggers is not currently supported",
-		"Index exceeds \\d+ columns"+tttSeparator+"For the maximum number of columns per index, 'included' columns do not count in SQL Server, but they do ount in PostgreSQL",
+		"Index exceeds \\d+ columns"+tttSeparator+"For the maximum number of columns per index, 'included' columns do not count in SQL Server, but they do count in PostgreSQL",
 		"DROP \\w+, >1 object"+tttSeparator+"Use a separate DROP statement for each object to be dropped",
 		"CREATE FUNCTION, \\w+( \\w+)?, atomic"+tttSeparator+"Atomic natively compiled functions are not currently supported; rewrite as a regular SQL functions",		
 		"CREATE FUNCTION, \\w+( \\w+)?, external"+tttSeparator+"External functions are not currently supported; rewrite as a regular SQL functions",		

--- a/src/main/java/compass/CompassUtilities.java
+++ b/src/main/java/compass/CompassUtilities.java
@@ -704,15 +704,13 @@ tooltipsHTMLPlaceholder +
 	public int capPosContext = 9;
 	public int capPosSubContext = 10;
 	public int capPosMisc = 11;
+	public int capPosLastField = 11 + 2;   // last field in a capture record; used to perform check on data read; +2 is for the 0 start index plus the extra field at the end
 
 	// first line in capture file:
 	public final String captureFileLinePart1 = "# Captured items for report ";
 	public final String captureFileLinePart2 = " with targeted "+babelfishProg+ "version ";
 	public final String captureFileLinePart3 = " generated at ";
 	public final String captureFileLinePart4 = " with capture file format ";
-
-	// line separator
-	public final String newLine = System.getProperty("line.separator");
 
 	// report generation
 	public String reportName = uninitialized;
@@ -4399,6 +4397,13 @@ tooltipsHTMLPlaceholder +
 				}
 
 				List<String> itemList = new ArrayList<String>(Arrays.asList(capLine.split(captureFileSeparator)));
+				// sanity checks on #fields on the line read
+				if (itemList.size() < capPosLastField) {
+					appOutput("\nError at line "+capCount+" of "+cf.toString()+":");					
+					appOutput("Invalid capture item read: expected "+(capPosLastField)+" fields, found "+itemList.size()+". Skipping this item:");
+					appOutput("["+capLine+"]");
+					continue;
+				}
 				String objType = getPatternGroup(itemList.get(capPosItem), "^CREATE (.*)$", 1);
 				if (objType.isEmpty()) {
 					objType = getPatternGroup(itemList.get(capPosItem), "^Constraint (.*?)(\\(.*)?$", 1);


### PR DESCRIPTION
### Description
Handles a case of an invalid input file
 
### Issues Resolved
When an DDL script contains a delimited identifier which contains a newline (odd, but not impossible), do not crash downstream but try to work around the issue and complete generating the assessment report
 
### Check List
- [ x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
