### PR TITLE
fix: Escape Special Characters for release.yml GPG Signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         mv BabelfishCompass/compass-*-jar-with-dependencies.jar BabelfishCompass/compass.jar
         export GPG_TTY=$(tty)
         KEYGRIP="$(gpg --with-keygrip -K | grep -Pom1 '^ *Keygrip += +\K.*')"
-        /usr/lib/gnupg2/gpg-preset-passphrase -c $KEYGRIP <<< ${{ secrets.GPG_PASSPHRASE }}
+        /usr/lib/gnupg2/gpg-preset-passphrase -c $KEYGRIP <<< "${{ secrets.GPG_PASSPHRASE }}"
         for jar in BabelfishCompass/*.jar; do gpg --detach-sign --armor $jar; done
         for signed in BabelfishCompass/*.asc; do gpg --verify $signed; done
         zip -r BabelfishCompass_${{ env.RELEASE_VERSION }}.zip BabelfishCompass

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         mv BabelfishCompass/compass-*-jar-with-dependencies.jar BabelfishCompass/compass.jar
         export GPG_TTY=$(tty)
         KEYGRIP="$(gpg --with-keygrip -K | grep -Pom1 '^ *Keygrip += +\K.*')"
-        /usr/lib/gnupg2/gpg-preset-passphrase -c $KEYGRIP <<< "${{ secrets.GPG_PASSPHRASE }}"
+        /usr/lib/gnupg2/gpg-preset-passphrase -c "$KEYGRIP" <<< "${{ secrets.GPG_PASSPHRASE }}"
         for jar in BabelfishCompass/*.jar; do gpg --detach-sign --armor $jar; done
         for signed in BabelfishCompass/*.asc; do gpg --verify $signed; done
         zip -r BabelfishCompass_${{ env.RELEASE_VERSION }}.zip BabelfishCompass


### PR DESCRIPTION
### Description
Add double quotes around the secret passphrase to escape special characters in the release workflow yaml file.

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
