### PR TITLE
Fix -recursive input to work with input files listed anywhere on the command line

### DIFF
--- a/src/main/java/compass/Compass.java
+++ b/src/main/java/compass/Compass.java
@@ -138,7 +138,11 @@ public class Compass {
 		for (int i = 0; i < args.length; i++) {
 			cmdFlags.add(args[i]);
 		}
-		
+
+		// Need to queue up the input files so we can process them after knowing whether any of
+		// -recursive, -include [pattern] or -exclude [pattern] have been set.
+		List<String> tmpInputFiles = new ArrayList<>();
+
 		for (int i = 0; i < args.length; ) {
 			String arg = args[i];
 			i++;
@@ -598,7 +602,7 @@ public class Compass {
 							arg = arg.replaceAll("\\\\", "");
 						}						
 					}
-					addInputFile(arg);
+					tmpInputFiles.add(arg);
 				}
 				continue;
 			}
@@ -607,7 +611,13 @@ public class Compass {
 			System.err.println("Invalid option ["+arg+"]. Try -help");
 			u.errorExit();
 		}
-		
+
+		// Now we can processes all of the input files and properly deal with
+		// -recursive, -include and -exclude
+		for (String file : tmpInputFiles) {
+			addInputFile(file);
+		}
+
 		if (u.debugging) u.dbgOutput(CompassUtilities.thisProc() + "onWindows=["+CompassUtilities.onWindows+"] onMac=["+CompassUtilities.onMac+"] onLinux=["+CompassUtilities.onLinux+"]  ", u.debugOS);
 		
 		inputFilesOrig.addAll(inputFiles);
@@ -938,7 +948,7 @@ public class Compass {
 				} // otherwise ignore directories
 			} else if (Files.isRegularFile(path) && (includes == null || includes.matches(path))
 					&& (excludes == null || !excludes.matches(path))) {
-				inputFiles.add(file);
+				inputFiles.add(path.toString());
 			} else {
 				// TODO log unexpected case here?
 				// File does not exist or can't be read by the current process


### PR DESCRIPTION
### Description
Prior to the new `-recursive` feature, you could type the input files anywhere on the command line (besides the 1st argument which is always the report name or as a value to an option that requires one). The input files were added to the collection of files for BabelfishCompass to process as we looped over the command line arguments. Now, with the new `-recursive` feature, we need to know whether any of `-recursive`, `-include [pattern]`, or `-exclude [pattern]` are set so we can properly process the input file string.
 
### Issues Resolved
#61 
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
