### PR TITLE
fix: Correct the date in CompassUtilities.java to 2022

### DIFF
--- a/src/main/java/compass/CompassUtilities.java
+++ b/src/main/java/compass/CompassUtilities.java
@@ -40,7 +40,7 @@ public class CompassUtilities {
 	public static String  onPlatform = uninitialized;
 
 	public static final String thisProgVersion      = "2022-03";
-	public static final String thisProgVersionDate  = "March 2023";
+	public static final String thisProgVersionDate  = "March 2022";
 	public static final String thisProgName         = "Babelfish Compass";
 	public static final String thisProgNameLong     = "Compatibility assessment tool for Babelfish for PostgreSQL";
 	public static final String thisProgNameExec     = "Compass";


### PR DESCRIPTION
This PR changes the version date in CompassUtilities.java from 2022 to 2023.

Signed-off-by: Sertay Sener <seners@amazon.com>

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
