### PR TITLE
support for INSTEAD OF triggers on tables in v.1.2.0

### DIFF
--- a/BabelfishFeatures.cfg
+++ b/BabelfishFeatures.cfg
@@ -437,6 +437,7 @@ report_group=Triggers
 [Instead-Of Trigger]
 rule=create_or_alter_dml_trigger
 list=TABLE,VIEW
+supported-1.2.0=TABLE
 report_group=Triggers
 
 [View options]
@@ -1100,5 +1101,5 @@ rule=system_versioning_options
 rule=conversation_statement
 
 #-----------------------------------------------------------------------------------
-#file checksum=db1fd68f
+#file checksum=c0804fbf
 #--- end ---------------------------------------------------------------------------

--- a/src/main/java/compass/CompassUtilities.java
+++ b/src/main/java/compass/CompassUtilities.java
@@ -39,7 +39,7 @@ public class CompassUtilities {
 	public static boolean onLinux    = false;
 	public static String  onPlatform = uninitialized;
 
-	public static final String thisProgVersion      = "2022-03";
+	public static final String thisProgVersion      = "2022-03-a";
 	public static final String thisProgVersionDate  = "March 2022";
 	public static final String thisProgName         = "Babelfish Compass";
 	public static final String thisProgNameLong     = "Compatibility assessment tool for Babelfish for PostgreSQL";
@@ -517,7 +517,7 @@ tooltipsHTMLPlaceholder +
 		"DISABLE TRIGGER"+tttSeparator+"Disabling triggers is not currently supported; triggers are always enabled",		
 		"ALTER TABLE..ENABLE TRIGGER"+tttSeparator+"Enabling triggers is not currently supported; triggers are always enabled",		
 		"ENABLE TRIGGER"+tttSeparator+"Enabling triggers is not currently supported; triggers are always enabled",		
-		"CREATE TRIGGER, INSTEAD OF"+tttSeparator+"INSTEAD-OF triggers are not currently supported. Rewrite as FOR trigger",		
+		"CREATE TRIGGER, INSTEAD OF"+tttSeparator+"This type of INSTEAD-OF trigger is not currently supported. Rewrite as FOR trigger",		
 		"CREATE TRIGGER (DDL"+tttSeparator+"DDL triggers are not currently supported",
 		CompassAnalyze.TriggerSchemaName+tttSeparator+"CREATE TRIGGER schemaname.triggername is not currently supported; Remove 'schemaname'",
 		"\\w+, WHERE CURRENT OF"+tttSeparator+"Updatable cursors are not currently supported. Rewrite the application to use direct UPDATE/DELETE",


### PR DESCRIPTION
### Description
support for INSTEAD OF triggers on tables in v.1.2.0
 
### Issues Resolved
support for INSTEAD OF triggers on tables in v.1.2.0
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
