### PR TITLE
doc: Fix Quotation Syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Allow generating a report only when analysis was done on an older Babelfish version.
 - Detecting and reporting scalar user-defined function calls in column defaults and CHECK constraints.
 - Line numbers in Xref reports were not correct for some index-related items.
-- '@@error value 50000, via THROW' now classified as supported.
+- `@@error value 50000, via THROW` now classified as supported.
 - Indexes with additional included columns exceeding the maximum of 32 now classified as 'Review Performance'.
 - Better error message for some cases of a non-existing report name.
 - Optimization for -pgimport.


### PR DESCRIPTION
### Description
`@@error value 50000, via THROW` was not properly enclosed in the CHANGELOG.md causing issues when generating the release notes by treating `@error` as a user and listing them as a contributor.
 
### Issues Resolved
n/a
 
### Check List
- [x] Commits are signed per the DCO using --signoff 
Signed-off-by: Colin Yuen [yuenhcol@amazon.com](mailto:yuenhcol@amazon.com)

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
