### PR TITLE
direct link to user guide .pdf doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For the compatibility matrix between Babelfish Compass and Babelfish, see the Us
 
 ## Documentation
 
-The User Guide is here: https://github.com/babelfish-for-postgresql/babelfish_compass/blob/main/BabelfishCompass_UserGuide.pdf
+The User Guide is here: https://raw.githubusercontent.com/babelfish-for-postgresql/babelfish_compass/main/BabelfishCompass_UserGuide.pdf
 
 
 ## Security


### PR DESCRIPTION
### Description
Direct link to PDF user guide doc on README page
 
### Issues Resolved
Direct link to PDF user guide doc on README page, since PDF doc got too large to be rendered directly by Github
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
