### PR TITLE
removed entry TRIM with N args

### DIFF
--- a/BabelfishCompassUser.Optimistic.cfg
+++ b/BabelfishCompassUser.Optimistic.cfg
@@ -751,13 +751,4 @@ default_classification=Ignored
 [DISTINCT FROM]
 
 
-[LTRIM with N arguments]
-
-
-[TRIM with N arguments]
-
-
-[RTRIM with N arguments]
-
-
 [STRING_SPLIT with N arguments]

--- a/BabelfishFeatures.cfg
+++ b/BabelfishFeatures.cfg
@@ -321,11 +321,6 @@ supported-1.0.0=1
 supported-1.2.0=0
 report_group=Built-in functions
 
-[TRIM with N arguments]
-rule=function_call
-supported-1.0.0=1
-report_group=Built-in functions
-
 [RTRIM with N arguments]
 rule=function_call
 supported-1.0.0=1
@@ -1419,5 +1414,5 @@ rule=execute_body
 default_classification=ReviewManually
 
 #-----------------------------------------------------------------------------------
-#file checksum=8f9f97f5
+#file checksum=5f618caa
 #--- end ---------------------------------------------------------------------------

--- a/BabelfishFeatures.cfg
+++ b/BabelfishFeatures.cfg
@@ -321,16 +321,6 @@ supported-1.0.0=1
 supported-1.2.0=0
 report_group=Built-in functions
 
-[RTRIM with N arguments]
-rule=function_call
-supported-1.0.0=1
-report_group=Built-in functions
-
-[LTRIM with N arguments]
-rule=function_call
-supported-1.0.0=1
-report_group=Built-in functions
-
 [STRING_SPLIT with N arguments]
 rule=function_call
 supported-1.0.0=2
@@ -1414,5 +1404,5 @@ rule=execute_body
 default_classification=ReviewManually
 
 #-----------------------------------------------------------------------------------
-#file checksum=5f618caa
+#file checksum=f0bb2843
 #--- end ---------------------------------------------------------------------------


### PR DESCRIPTION
### Description
Removed entry TRIM with N args from .cfg file
 
### Issues Resolved
Removed entry TRIM with N args from .cfg file
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
