### PR TITLE
Added DEFAULT parameters as supported in 3.4.0

### DIFF
--- a/BabelfishFeatures.cfg
+++ b/BabelfishFeatures.cfg
@@ -634,9 +634,10 @@ report_group=Views
 
 [Parameter value DEFAULT]
 rule=execute_parameter,function_call
-list=procedure,function
-report_group-Procedures=procedure
-report_group-Functions=function
+list=PROCEDURE,FUNCTION
+supported-3.4.0=PROCEDURE,FUNCTION
+report_group-Procedures=PROCEDURE
+report_group-Functions=FUNCTION
 
 [Maximum parameters per procedure]
 rule=create_or_alter_procedure
@@ -1570,5 +1571,5 @@ rule=sqlcmd_variable
 default_classification=ReviewManually
 
 #-----------------------------------------------------------------------------------
-#file checksum=d6650fbb
+#file checksum=1a97666b
 #--- end ---------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+# 2023-12-a
+- Added DEFAULT parameters as supported in 3.4.0 (previously omitted).
+
 # 2023-12
 - Updated support for Babelfish v.3.4.0.
 


### PR DESCRIPTION
### Description
Added DEFAULT parameters as supported in 3.4.0 (previously omitted).
 
### Issues Resolved
Added DEFAULT parameters as supported in 3.4.0 (previously omitted).
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
