### PR TITLE
Mark PERCENTILE_CONT() and PERCENTILE_DISC() as not supported

### DIFF
--- a/BabelfishFeatures.cfg
+++ b/BabelfishFeatures.cfg
@@ -246,7 +246,7 @@ default_classification=ReviewSemantics
 [Aggregate functions]
 rule=aggregate_windowed_function,ranking_windowed_function,analytic_windowed_function
 list=SUM,AVG,MAX,MIN,COUNT,COUNT_BIG,APPROX_COUNT_DISTINCT,CHECKSUM_AGG,CUME_DIST,DENSE_RANK,DENSE_RANK,DISTINCT,FIRST_VALUE,GROUPING,GROUPING_ID,LAG,LAST_VALUE,LEAD,NTILE,PERCENTILE_CONT,PERCENTILE_DISC,PERCENT_RANK,RANK,ROW_NUMBER,STDEV,STDEVP,STRING_AGG,VAR,VARP,APPROX_PERCENTILE_CONT,APPROX_PERCENTILE_DISC
-supported-1.0.0=SUM,AVG,MAX,MIN,COUNT,COUNT_BIG,CUME_DIST,DENSE_RANK,DENSE_RANK,DISTINCT,FIRST_VALUE,GROUPING,LAG,LAST_VALUE,LEAD,NTILE,PERCENTILE_CONT,PERCENTILE_DISC,PERCENT_RANK,RANK,ROW_NUMBER,STRING_AGG
+supported-1.0.0=SUM,AVG,MAX,MIN,COUNT,COUNT_BIG,CUME_DIST,DENSE_RANK,DENSE_RANK,DISTINCT,FIRST_VALUE,GROUPING,LAG,LAST_VALUE,LEAD,NTILE,PERCENT_RANK,RANK,ROW_NUMBER,STRING_AGG
 supported-3.2.0=STDEV,STDEVP,VAR,VARP
 
 [Built-in functions]
@@ -1681,5 +1681,5 @@ report_group=Identifiers
 complexity_score=LOW
 
 #-----------------------------------------------------------------------------------
-#file checksum=b4ac16b3
+#file checksum=b429f2f8
 #--- end ---------------------------------------------------------------------------


### PR DESCRIPTION
### Description
Mark PERCENTILE_CONT() and PERCENTILE_DISC() as not supported
 
### Issues Resolved
Mark PERCENTILE_CONT() and PERCENTILE_DISC() as not supported
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
