### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '8'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: maven
     - name: Build with Maven
       run: |


### PR DESCRIPTION
### Description
Updated from actions/checkout@v2 to actions/checkout@v3 and  actions/setup-java@v2 to actions/setup-java@v3.
Updated distribution : 'adopt' to 'temurin'

This is done to resolve following cache error:
`Error: getCacheEntry failed: Request timeout: .../_apis/artifactcache/cache?keys=setup-java-Linux-maven-...-setup-java-Linux-maven&version=...
` 

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
