### PR TITLE
Support geospatial functions MakeValid, STNumPoints, Parse, STGeometr…

### DIFF
--- a/BabelfishFeatures.cfg
+++ b/BabelfishFeatures.cfg
@@ -229,6 +229,7 @@ supported-4.7.0-4.*=HASZ,HASM,Z,M
 supported-5.3.0=HASZ,HASM,Z,M
 supported-5.4.0=STLINEFROMTEXT
 supported-5.5.0=STPOLYFROMTEXT
+supported-5.6.0=MAKEVALID,STNUMPOINTS,PARSE,STGEOMETRYTYPE,STMPOINTFROMTEXT
 report_group=Geospatial
 complexity_score=HIGH
 
@@ -238,6 +239,7 @@ supported-3.5.0-3.*=POINT
 supported-4.1.0=POINT
 supported-5.4.0=LINESTRING
 supported-5.5.0=POLYGON
+supported-5.6.0=MULTIPOINT
 report_group=Geospatial
 complexity_score=HIGH
 default_classification-ReviewSemantics=expression
@@ -1716,5 +1718,5 @@ report_group=Identifiers
 complexity_score=LOW
 
 #-----------------------------------------------------------------------------------
-#file checksum=4265fcea
+#file checksum=55a166f7
 #--- end ---------------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 2026-06
 - Added support for Babelfish v.6.0.0.
+- Added geospatial function: MAKEVALID, STNUMPOINTS, PARSE, STGEOMETRYTYPE, STMPOINTFROMTEXT as supported
+- Added geospatial feature: MULTIPOINT (STGeomFromText) as supported
 
 # 2026-04
 - Added support for Babelfish v.5.5.0.

--- a/src/main/java/compass/CompassAnalyze.java
+++ b/src/main/java/compass/CompassAnalyze.java
@@ -6217,7 +6217,17 @@ public class CompassAnalyze {
 
 			@Override public String visitHierarchyid_coloncolon_methods(TSQLParser.Hierarchyid_coloncolon_methodsContext ctx) {
 				if (u.debugging) dbgTraceVisitEntry(CompassUtilities.thisProc());
-				captureHIERARCHYIDFeature("HIERARCHYID.", ctx.method.getText().toUpperCase(), "()", ctx.start.getLine());
+				String method = ctx.method.getText().toUpperCase();
+				// PARSE/GETROOT with a GEOMETRY/GEOGRAPHY prefix (e.g. geometry::Parse(...)) is a spatial call, not HIERARCHYID
+				String prefix = (ctx.id() != null) ? u.normalizeName(ctx.id().getText()).toUpperCase() : "";
+				if (prefix.equals("GEOMETRY") || prefix.equals("GEOGRAPHY")) {
+					String status = featureSupportedInVersion(Geospatial, method);
+					// display the method with its original case, consistent with the other spatial-method paths
+					captureItem(SpatialMethodCallFmt + " " + ctx.method.getText(), "", SpatialReportGroup, "", status, ctx.start.getLine());
+				}
+				else {
+					captureHIERARCHYIDFeature("HIERARCHYID.", method, "()", ctx.start.getLine());
+				}
 				visitChildren(ctx);
 				if (u.debugging) dbgTraceVisitExit(CompassUtilities.thisProc());
 				return null;


### PR DESCRIPTION
 ### Description

  Adds Compass support for the geospatial functions and the Multipoint feature introduced in Babelfish v.6.1.0:

  - **`BabelfishFeatures.cfg`** — under `[Geospatial features]`, marks `MAKEVALID`, `STNUMPOINTS`, `PARSE`, `STGEOMETRYTYPE`, and `STMPOINTFROMTEXT` as supported from
  v.5.6.0; under `[STGEOMFROMTEXT]`, marks `MULTIPOINT` as a supported geometry type from v.5.6.0. Checksum regenerated accordingly.
  - **`CompassAnalyze.java`** — fixes a routing bug in `visitHierarchyid_coloncolon_methods`: previously every `X::Parse` / `X::GetRoot` call was unconditionally
  classified as `HIERARCHYID.Parse()` (Not Supported), so `geometry::Parse(...)` / `geography::Parse(...)` were wrongly reported as not supported. Now, when the prefix
  is `GEOMETRY`/`GEOGRAPHY`, the call is routed to the Geospatial path and classified against the `[Geospatial features]` config. HIERARCHYID prefixes are unaffected.
  - **`CHANGELOG.md`** — adds the v.6.1.0 geospatial entries.

  Verified end-to-end against a freshly built jar: at v.6.1.0 all five functions and Multipoint report as **Supported** (0 not-supported); at v.5.5.0 they correctly
  report **Not Supported** (version gating intact); and real `hierarchyid::Parse` / `hierarchyid::GetRoot` continue to classify as HIERARCHYID (no regression).

  ### Issues Resolved

  - BABEL-6310 — Support MakeValid, STNumPoints, Parse, STGeometryType for geospatial datatypes
  - BABEL-6348 — Support for Multipoint in Babelfish

  Authored-by: Gopal Verma <gopalgv@amazon.com>

  ### Check List
  - [x] Commits are signed per the DCO using --signoff

  By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

  For more information on following Developer Certificate of Origin and signing off your commits, please check
  [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
