### PR TITLE
Add INSERT-EXEC support for SP_EXECUTESQL and dynamic sql in 5.7.0

### DIFF
--- a/BabelfishFeatures.cfg
+++ b/BabelfishFeatures.cfg
@@ -15,10 +15,10 @@
 # this must always be the first section:
 [Babelfish for T-SQL]
 # only Babelfish version numbers listed here can be referenced the rules below:
-valid_versions=1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.5.0, 1.6.0, 2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 3.1.0, 3.2.0, 3.3.0, 3.4.0, 3.5.0, 4.0.0, 4.1.0, 4.2.0, 4.3.0, 4.4.0, 4.5.0, 4.6.0, 4.7.0, 4.8.0, 5.1.0, 5.2.0, 5.3.0, 5.4.0, 5.5.0, 5.6.0, 6.0.0, 6.1.0
+valid_versions=1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.5.0, 1.6.0, 2.1.0, 2.2.0, 2.3.0, 2.4.0, 2.5.0, 3.1.0, 3.2.0, 3.3.0, 3.4.0, 3.5.0, 4.0.0, 4.1.0, 4.2.0, 4.3.0, 4.4.0, 4.5.0, 4.6.0, 4.7.0, 4.8.0, 5.1.0, 5.2.0, 5.3.0, 5.4.0, 5.5.0, 5.6.0, 5.7.0, 6.0.0, 6.1.0
 # x.y.1/2/3 etc are bugfix releases for x.y.0 (no new T-SQL features supported), and are typically based on a newer PG release
 file_format=2                           # version number for format of this .cfg file. This is not expected to change much 
-file_timestamp=Jul-2026                 # identifies the version of this file, together with the latest Babelfish version supported
+file_timestamp=Aug-2026                 # identifies the version of this file, together with the latest Babelfish version supported
                                         # format: dd-MON-yyyy or MON-yyyy
 
 # Basic principle:
@@ -1304,6 +1304,7 @@ supported-1.0.0=VALUES,SELECT,EXECUTE PROCEDURE,CTE,OUTPUT
 supported-2.1.0=EXECUTE(STRING)
 supported-4.8.0-4.*=DEFAULT VALUES
 supported-5.4.0=DEFAULT VALUES
+supported-5.7.0=EXECUTE SP_EXECUTESQL,EXECUTE(EXPRESSION)
 ReviewSemantics-3.2.0=TOP
 default_classification-ReviewSemantics=TOP
 report_group=DML


### PR DESCRIPTION
…ported in 5.7.0

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish_internal/CONTRIBUTING.md#developer-certificate-of-origin).
